### PR TITLE
Use module scope for component manager association

### DIFF
--- a/addon/instance-initializers/ember-statechart-component-setup.ts
+++ b/addon/instance-initializers/ember-statechart-component-setup.ts
@@ -4,15 +4,9 @@ import ComponentManager from 'ember-statechart-component/-private/statechart-man
 import { StateNode } from 'xstate';
 
 // Managers are managed globally, and not per app instance
-let registered = false;
+setComponentManager((owner) => ComponentManager.create(owner), StateNode.prototype);
 
-export function initialize(): void {
-  if (registered) return;
-
-  setComponentManager((owner) => ComponentManager.create(owner), StateNode.prototype);
-
-  registered = true;
-}
+export function initialize(): void {}
 
 export default {
   initialize,


### PR DESCRIPTION
Instead of tracking a boolean and side effecting only once (after initializers run), do it in module scope when required. It has the same result, but is easier to reason about.