### PR TITLE
feat: support accessing services

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ export default createMachine({
 });
 ```
 
-Usage of this "toggle" component:
+Usage:
 
 ```hbs
 <Toggle as |state send|>
@@ -50,6 +50,53 @@ The default template for every `createMachine(..)` is
 ```
 but that can be overriden to suit your needs by defining your own template.
 the `this` is an instance of the [XState Interpreter](https://xstate.js.org/api/classes/interpreter.html)
+
+### Accessing Services
+
+```js
+// app/components/authenticated-toggle.js
+import { getService } from 'ember-statechart-component';
+import { createMachine } from 'xstate';
+
+export default createMachine({
+  initial: 'inactive',
+  states: {
+    inactive: {
+      on: {
+        TOGGLE: [
+          {
+            target: 'active',
+            cond: 'isAuthenticated',
+          },
+          { actions: ['notify'] },
+        ],
+      },
+    },
+    active: { on: { TOGGLE: 'inactive' } },
+  },
+}, {
+  actions: {
+    notify: (ctx) => {
+      getService(ctx, 'toasts').notify('You must be logged in');
+    },
+  },
+  guards: {
+    isAuthenticated: (ctx) => getService(ctx, 'session').isAuthenticated,
+  },
+});
+```
+
+Usage:
+
+```hbs
+<AuthenticatedToggle as |state send|>
+  {{state.value}}
+
+  <button type='button' {{on 'click' (fn send 'TOGGLE')}}>
+    Toggle
+  </button>
+</AuthenticatedToggle>
+```
 
 ### API
 

--- a/addon/-private/statechart-manager.ts
+++ b/addon/-private/statechart-manager.ts
@@ -25,8 +25,7 @@ export default class ComponentManager {
     updateHook: true,
   });
 
-  static create(attrs: unknown) {
-    let owner = getOwner(attrs);
+  static create(owner: unknown) {
     let manager = new ComponentManager();
 
     setOwner(manager, owner);
@@ -41,9 +40,15 @@ export default class ComponentManager {
       machine = machine.withConfig(named.config as any);
     }
 
+    let context = {};
+
     if ('context' in named) {
-      machine = machine.withContext(named.context);
+      Object.assign(context, named.context);
     }
+
+    setOwner(context, getOwner(this));
+
+    machine = machine.withContext(context);
 
     let interpreter = interpret(machine, {
       devTools: DEBUG,

--- a/addon/index.ts
+++ b/addon/index.ts
@@ -1,0 +1,14 @@
+import { getOwner } from '@ember/application';
+import { assert } from '@ember/debug';
+
+import type { Registry } from '@ember/service';
+
+export function getService<Key extends keyof Registry>(context: unknown, serviceName: Key) {
+  let owner = getOwner(context);
+
+  assert(`Expected passed context to be aware of the container (owner)`, owner);
+
+  let service = owner.lookup(`service:${serviceName}`) as Registry[Key];
+
+  return service;
+}


### PR DESCRIPTION
There is a new utility,

```js
import { getService} from 'ember-statechart-component';
```

that can be used on _any_ XState supported function that has
access to the context.

For example, in a machine definition, these actions and guards
can access the `toasts` and `session` service.
```js
  actions: {
    notify: (ctx) => {
      getService(ctx, 'toasts').notify('You must be logged in');
    },
  },
  guards: {
    isAuthenticated: (ctx) => getService(ctx, 'session').isAuthenticated,
  },
```