### PR TITLE
Add minimum browser support

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ Compatibility
 
 * Ember.js v3.25 or above
 * Node.js v12 or above
+* Chrome 49 / Edge 12 / Firefox 42 / Safari 10
 
 
 Contributing

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ Compatibility
 
 * Ember.js v3.25 or above
 * Node.js v12 or above
-* Chrome 49 / Edge 12 / Firefox 42 / Safari 10
+* A browser that supports [Proxy](https://caniuse.com/proxy)
 
 
 Contributing


### PR DESCRIPTION
This addon uses Proxy and Reflect.get which requires more or less modern browser per MDN
* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Reflect/get#browser_compatibility
* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy#browser_compatibility