### PR TITLE
chore(readme): explain role of ember-could-get-used-to-this better

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,15 +24,15 @@ To be able to use XState [`state.matches`](https://xstate.js.org/docs/guides/sta
 method in our templates,
 we will first need a `HelperManager` for
 handling vanilla functions.
-[ember-could-get-used-to-this](https://github.com/pzuraq/ember-could-get-used-to-this)
+[ember-functions-as-helper-polyfill](https://github.com/NullVoxPopuli/ember-functions-as-helper-polyfill)
 provides one:
 
 ```bash
-ember install ember-could-get-used-to-this
+ember install ember-functions-as-helper-polyfill
 # or
-npm install ember-could-get-used-to-this
+npm install ember-functions-as-helper-polyfill
 # or
-yarn add ember-could-get-used-to-this
+yarn add ember-functions-as-helper-polyfill
 ```
 
 Usage

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ yarn add ember-statechart-component
 
 ### Optional
 
-To be able to use XState [`state.matches`](https://xstate.js.org/api/classes/state.html#matches)
+To be able to use XState [`state.matches`](https://xstate.js.org/docs/guides/states.html#state-matches-parentstatevalue)
 method in our templates,
 we will first need a `HelperManager` for
 handling vanilla functions.

--- a/README.md
+++ b/README.md
@@ -18,8 +18,6 @@ npm install ember-statechart-component
 yarn add ember-statechart-component
 ```
 
-### Optional
-
 To be able to use XState [`state.matches`](https://xstate.js.org/docs/guides/states.html#state-matches-parentstatevalue)
 method in our templates,
 we will first need a [HelperManager](https://github.com/emberjs/rfcs/pull/625) for

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ yarn add ember-statechart-component
 
 To be able to use XState [`state.matches`](https://xstate.js.org/docs/guides/states.html#state-matches-parentstatevalue)
 method in our templates,
-we will first need a `HelperManager` for
+we will first need a [HelperManager](https://github.com/emberjs/rfcs/pull/625) for
 handling vanilla functions.
 [ember-functions-as-helper-polyfill](https://github.com/NullVoxPopuli/ember-functions-as-helper-polyfill)
 provides one:

--- a/README.md
+++ b/README.md
@@ -18,6 +18,23 @@ npm install ember-statechart-component
 yarn add ember-statechart-component
 ```
 
+### Optional
+
+To be able to use XState [`state.matches`](https://xstate.js.org/api/classes/state.html#matches)
+method in our templates,
+we will first need a `HelperManager` for
+handling vanilla functions.
+[ember-could-get-used-to-this](https://github.com/pzuraq/ember-could-get-used-to-this)
+provides one:
+
+```bash
+ember install ember-could-get-used-to-this
+# or
+npm install ember-could-get-used-to-this
+# or
+yarn add ember-could-get-used-to-this
+```
+
 Usage
 ------------------------------------------------------------------------------
 
@@ -103,14 +120,6 @@ Usage:
 ```
 
 ### Matching States
-
-XState provides its own [`matches`](https://xstate.js.org/api/classes/state.html#matches)
-method which is available on the `state` object.
-We can utilize this provided there exists a `HelperManager` for
-handling vanilla functions, such as what
-[ember-could-get-used-to-this](https://github.com/pzuraq/ember-could-get-used-to-this)
-provides.
-
 
 ```hbs
 <Toggle as |state send|>


### PR DESCRIPTION
- Sections should be complete. If I finish `installation` part of
  README, I should not need to hunt down for anything that might
  be missing.
- Be explicit: Do X, instead of generic description of what is the
  idea and leave user wondering.
- Explicitly mentioned that it's because of _templates_ code
- Second commit: docs link instead of API link
  - The docs link provide nice example of the syntax
  - Hints the dot notation, which will be probably preferred in templates