### PR TITLE
@config example

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,41 @@ provides.
 
 This argument allows you to pass a `MachineConfig` for [actions](https://xstate.js.org/docs/guides/actions.html), [services](https://xstate.js.org/docs/guides/communication.html#invoking-services), [guards](https://xstate.js.org/docs/guides/guards.html#guards-condition-functions), etc.
 
+```js
+// app/components/toggle.js
+import { createMachine, assign } from 'xstate';
+
+export default createMachine({
+  initial: 'inactive',
+  states: {
+    inactive: { on: { TOGGLE: 'active' } },
+    active: { 
+      on: { 
+        TOGGLE: {
+          target: 'inactive',
+          actions: ['toggleIsOn']
+        }
+      }
+    },
+  },
+});
+```
+
+Usage:
+
+```hbs
+<Toggle 
+  @config={{hash 
+    actions=(hash 
+      toggleIsOn=@onRoomIlluminated
+    )
+  }} 
+as |state send|>
+  <button {{on 'click' (fn send 'TOGGLE')}}>
+    Toggle
+  </button>
+</Toggle>
+```
 
 #### `@context`
 

--- a/README.md
+++ b/README.md
@@ -132,7 +132,8 @@ provides.
 
 #### `@config`
 
-This argument allows you to pass a `MachineConfig` for actions, services, guards, etc
+This argument allows you to pass a `MachineConfig` for [actions](https://xstate.js.org/docs/guides/actions.html), [services](https://xstate.js.org/docs/guides/communication.html#invoking-services), [guards](https://xstate.js.org/docs/guides/guards.html#guards-condition-functions), etc.
+
 
 #### `@context`
 


### PR DESCRIPTION
- Give links to actions, services, guards
- Also "etc." should end with a dot
- A code example for @config