### PR TITLE
Try out using <details> to hide less important details to the readme docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,10 @@ provides.
 
 This argument allows you to pass a `MachineConfig` for [actions](https://xstate.js.org/docs/guides/actions.html), [services](https://xstate.js.org/docs/guides/communication.html#invoking-services), [guards](https://xstate.js.org/docs/guides/guards.html#guards-condition-functions), etc.
 
+Usage:
+
+<details><summary>Toggle machine that needs a config</summary>
+  
 ```js
 // app/components/toggle.js
 import { createMachine, assign } from 'xstate';
@@ -154,7 +158,7 @@ export default createMachine({
 });
 ```
 
-Usage:
+</details>
 
 ```hbs
 <Toggle 
@@ -173,6 +177,10 @@ as |state send|>
 #### `@context`
 
 Sets the initial context. The current value of the context can then be accessed via `state.context`.
+
+Usage:
+
+<details><summary>Toggle machine that interacts with context</summary>
 
 ```js
 // app/components/toggle.js
@@ -207,7 +215,7 @@ export default createMachine({
 });
 ```
 
-Usage:
+</details>
 
 ```hbs
 <Toggle @context=(hash counter=0) as |state send|>


### PR DESCRIPTION
@MichalBryxi idk how you feel about this, but for these parts of the docs, idk that the machine definition is all that important, ya know? Like, it's useful, but because they're so big, they may be a bit verbose or distract?