### PR TITLE
docs: ambiguous service word

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ The default template for every `createMachine(..)` is
 but that can be overriden to suit your needs by defining your own template.
 The `this` is an instance of the [XState Interpreter](https://xstate.js.org/api/classes/interpreter.html)
 
-### Accessing Services
+### Accessing EmberJS Services
 
 ```js
 // app/components/authenticated-toggle.js


### PR DESCRIPTION
The wording did not give a hint whether we're talking about [EmberJS services](https://guides.emberjs.com/release/services/) or [Invoking Services](https://xstate.js.org/docs/guides/communication.html#the-invoke-property) section of the xstate guides