### PR TITLE
docs: better link for services and guards

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ Usage:
 
 #### `@config`
 
-This argument allows you to pass a `MachineConfig` for [actions](https://xstate.js.org/docs/guides/actions.html), [services](https://xstate.js.org/docs/guides/communication.html#invoking-services), [guards](https://xstate.js.org/docs/guides/guards.html#guards-condition-functions), etc.
+This argument allows you to pass a MachineConfig for [actions](https://xstate.js.org/docs/guides/actions.html), [services](https://xstate.js.org/docs/guides/communication.html#configuring-services), [guards](https://xstate.js.org/docs/guides/guards.html#serializing-guards), etc.
 
 Usage:
 


### PR DESCRIPTION
- While docs of actions have nice example of syntax
  where string is used to reference a key in the `options` object,
  services and guards don't have it (on the top).
- These links should allow user quicker scan of the expected syntax.