### PR TITLE
fix(@config): this arg is actually a `MachineOptions` type

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ declare module "@glint/environment-ember-loose/registry" {
 
 #### `@config`
 
-This argument allows you to pass a MachineConfig for [actions](https://xstate.js.org/docs/guides/actions.html), [services](https://xstate.js.org/docs/guides/communication.html#configuring-services), [guards](https://xstate.js.org/docs/guides/guards.html#serializing-guards), etc.
+This argument allows you to pass a [MachineOptions](https://xstate.js.org/docs/packages/xstate-fsm/#api) for [actions](https://xstate.js.org/docs/guides/actions.html), [services](https://xstate.js.org/docs/guides/communication.html#configuring-services), [guards](https://xstate.js.org/docs/guides/guards.html#serializing-guards), etc.
 
 Usage:
 

--- a/ember-statechart-component/src/glint.ts
+++ b/ember-statechart-component/src/glint.ts
@@ -8,6 +8,7 @@ import type {
   EventObject,
   Interpreter,
   MachineConfig,
+  MachineOptions,
   NoInfer,
   ResolveTypegenMeta,
   ServiceMap,
@@ -49,7 +50,7 @@ declare module 'xstate' {
     TResolvedTypesMeta = ResolveTypegenMeta<TypegenDisabled, NoInfer<TEvent>, TAction, TServiceMap>
   > extends ComponentLike<{
       Args: {
-        config?: MachineConfig<TContext, TStateSchema, TEvent>;
+        config?: MachineOptions<TContext, TEvent, TAction, TServiceMap>;
         context?: TContext;
         state?: Interpreter<TContext, TStateSchema, TEvent, TTypestate>['state'];
       };


### PR DESCRIPTION
Resolves: https://github.com/NullVoxPopuli/ember-statechart-component/issues/268

There is a bit of a nomenclature mismatch in XState's docs and that is
reported here: https://github.com/statelyai/xstate/issues/3165