### PR TITLE
set type=module

### DIFF
--- a/ember-statechart-component/package.json
+++ b/ember-statechart-component/package.json
@@ -4,6 +4,7 @@
   "keywords": [
     "ember-addon"
   ],
+  "type": "module",
   "description": "Use XState Machines *as* Components",
   "repository": "https://github.com/NullVoxPopuli/ember-statechart-component",
   "license": "MIT",


### PR DESCRIPTION
This is breaking for older versions of ember-auto-import and embroider.

At the time of writing, you'll need at least:
- ember-auto-import@2.5.0
- embroider v4