### PR TITLE
Second yielded argument on machine is not send

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,8 +172,8 @@ export default createMachine({
       toggleIsOn=@onRoomIlluminated
     )
   }}
-as |state send|>
-  <button {{on 'click' (fn send 'TOGGLE')}}>
+as |toggle|>
+  <button {{on 'click' (fn toggle.send 'TOGGLE')}}>
     Toggle
   </button>
 </Toggle>


### PR DESCRIPTION
Trying to play with it and I don't think `send` in following code will be anything:

```gts
<Toggle as |machine send|>
  ...
</Toggle>
```

But `machine.send` exists and seems to be doing what one would expect.